### PR TITLE
Support for suspension curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ At the end of all this you now have 5 piecewise defined functions that give
 the leverage of on the shock at any given stroke... which inserted into hooks
 law at each interval produce:
 
-TODO: insert formula 
+$$y = mx - my + ln(mX+b) - ln(\frac{kx}{wr})$$
 
 As far as I know, this function is considered [transcendental](https://en.wikipedia.org/wiki/Transcendental_function)
 because isolating the sag (x) is not possible. To solve, you have to use
@@ -150,7 +150,3 @@ analytical methods to zero in on the solution. I use
 [newtons method](https://en.wikipedia.org/wiki/Newton%27s_method) in this case.
 
 Evaluating this on each interval of our curve gives us our sag.
-
-
-TODO: upload images of notes for future reference
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,156 @@
+# Coil Calculator
+
+A calculator to determine the amount of stroke displacement (sag) on the
+rear suspension of a mountain bike a particuler rider will produce with a
+particule coil spring.
+
+## The Math
+
+The math to produce sag calculations is dead simple in the base case.
+
+We can use:
+
+- Rider weight and rear wheel bias to determine the "normalized" weight
+- Stroke and wheel travel to generate a leverage ratio
+- [Hooks law](https://en.wikipedia.org/wiki/Hooke%27s_law) to determine
+the spring displacement based on the riders force
+
+Assuming that the suspension platform has a linear leverage curve (more on
+this later) you can represent the sag with algebra and solve it straight
+forwardly.
+
+This approach worked well for the first version of this tool, but in
+trying to represent the reality of suspension design this becomes a larger
+problem and moves us into non-linear suspension curves and calculus.
+
+### Leverage Curves
+
+As a mountain bike moves through the suspension, the force exerted on
+the shock changes. Different suspension platforms have different curves,
+and the leverage curves they create will have an affect on compression of
+the spring.
+
+Some platforms start with a high leverage ratio which reduces, others the
+opposite, and others make 'U' or other shapes.
+
+Here is an article I found that dives deeper into this.
+[TODO: fully read to verifiy its good](https://vorsprungsuspension.com/blogs/learn/understanding-leverage-curves)
+
+This means our once simple algebra equations now needs to incorporate this curve
+data. Said in another way, our equation needs to account for difference forces
+at different spring displacements.
+
+#### What a Leverage Curve Represents
+
+"Leverage" as these curves refer to it, is the change in wheel travel compared
+to the change in shock stroke. These leverage curves typically use wheel travel
+on the x axis, so that is the convention that I have stuck with in this calculator.
+
+Think about what this line represents...
+
+The curve *really* defines the position of the stroke in relation to the position of
+the wheel travel. And based on the leverage at any given point, the end result
+**must be that when the wheel moves fully through its travel, the shock moves
+fully through its stroke... EXACTLY**. Not more, not less.
+
+This should ring a bell! What these leverage curves really are, are reciprical
+derivitives of wheel travel vs shock stroke!
+
+Consider a typical derivitive graph you might have in math class.
+
+```
+x axis is x
+y axis dy/dx (slope, rise over run, tangent... whatever you call it)
+```
+
+What we have is sooooo close to this.
+
+```
+x axis is wheel travel
+y axis is wheel travel / shock stroke
+```
+
+In order to get to a traditional derivitive we need to flip that from "run
+over rise" to "rise over run" and we can do that by taking the reciprical of
+the leverage curve. At that point we'll then have a traditional derivitive.
+
+```
+x axis is wheel travel
+y axis is shock stroke / wheel travel
+```
+
+Consider a bike with 160mm of wheel travel and a 60mm shock stroke. Whats the
+area under this new (reciprical) leverage curve? 60mm!
+
+**Taking the integral of the reciprical of the leverage curve from 0 to the 
+end of the wheel travel MUST ALWAYS equal the shock stroke**. This fact should
+help understand what these curves represent.
+
+
+#### Selecting a Leverage Curve
+
+We need a way for the user to be able to provide the calculator with one of
+these leverage curves. There a a couple ways to do this: presets for different
+bikes, different platforms, or maybe even allowing the user to draw the pivots
+and calculate the leverage curve from that. I opted for something else.
+
+The solution I went for is to provide 6 (for example) "handles" on a curve
+that the user can drag up and down to match the curve of their bike.
+
+I saw it the customization and accompanying math was going to be innevitable.
+I can always add presets later.
+
+**The resulting curve looks like a smooth curve but that is purely a cosmetic
+desicion. In reality, we have 5 piecewise defined straight lines**
+
+While you could use either a single or piecewise defined curve(s) to drive 
+the underlying math, using piecewise defined linear equations make the math
+much more approachable with negligable (non existant) real world difference
+when all is said and done.
+
+**So you can create any curve you want?**
+
+No, you cannot. Remember, there is underlying math that defines what a valid
+curve is.
+
+If you adjust the curve you'll notice that every adjustment creates automatic
+adjustments to every other part of the curve. The area under the reciprical of
+this curve must never change, and that is what you see happen.
+
+Ensuring this is the case is what dictates the set of curves that a user can
+move through. It may seem infinetely adjustable, but its actually a finite set.
+
+
+#### Applying the Curve
+
+In order to insert the leverage curve into hooks law, we need to do a few
+transformation to it. Right now its 5 piecewise defined lines, with leverage on
+the y axis and wheel travel on the x axis. For hooks law, we need to know the
+instantanious leverage at any give shock stroke... not wheel travel.
+
+We can get to this through a series of transformations to each of our piecewise
+defined lines.
+
+1. Take the reciprical to get the d/dx of stroke to travel
+2. Take the integral to get the mapping of stroke (y) to travel (x)
+3. Take the inverse to the the mapping of travel (y) to stroke (x)
+4. Take the derivitive to get the d/dx of travel to stroke  <-- THIS IS WHAT WE WANT
+
+There may be an easier way to go from 1 to 4... but I couldn't reason about that.
+
+At the end of all this you now have 5 piecewise defined functions that give
+the leverage of on the shock at any given stroke... which inserted into hooks
+law at each interval produce:
+
+TODO: insert formula 
+
+As far as I know, this function is considered [transcendental](https://en.wikipedia.org/wiki/Transcendental_function)
+because isolating the sag (x) is not possible. To solve, you have to use
+analytical methods to zero in on the solution. I use
+[newtons method](https://en.wikipedia.org/wiki/Newton%27s_method) in this case.
+
+Evaluating this on each interval of our curve gives us our sag.
+
+
+TODO: upload images of notes for future reference
+

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ the spring.
 Some platforms start with a high leverage ratio which reduces, others the
 opposite, and others make 'U' or other shapes.
 
-Here is an article I found that dives deeper into this.
-[TODO: fully read to verifiy its good](https://vorsprungsuspension.com/blogs/learn/understanding-leverage-curves)
-
 This means our once simple algebra equations now needs to incorporate this curve
 data. Said in another way, our equation needs to account for difference forces
 at different spring displacements.

--- a/README.md
+++ b/README.md
@@ -140,13 +140,20 @@ There may be an easier way to go from 1 to 4... but I couldn't reason about that
 
 At the end of all this you now have 5 piecewise defined functions that give
 the leverage of on the shock at any given stroke... which inserted into hooks
-law at each interval produce:
+law at each interval produce the following line, which we must find its root:
 
-$$y = mx - my + ln(mX+b) - ln(\frac{kx}{wr})$$
+$$y = mx - mY + ln(mX+b) - ln(\frac{kx}{wr})$$
+
+- m, b, are the variables in each leverage curve intervals line (y = mx + b)
+- X, Y are coordinates at the end of the previous intervals integral
+- w is the weight of the rider
+- r is the rear wheel bias (0-1)
+- k is the spring weight
 
 As far as I know, this function is considered [transcendental](https://en.wikipedia.org/wiki/Transcendental_function)
-because isolating the sag (x) is not possible. To solve, you have to use
-analytical methods to zero in on the solution. I use
-[newtons method](https://en.wikipedia.org/wiki/Newton%27s_method) in this case.
+because isolating the sag (x) is not possible, which is why we are using root
+finding at all. To solve, you have to use analytical methods to zero in on the
+solution. I use [newtons method](https://en.wikipedia.org/wiki/Newton%27s_method)
+in this case.
 
 Evaluating this on each interval of our curve gives us our sag.

--- a/index.html
+++ b/index.html
@@ -74,11 +74,12 @@
     <canvas id="curve"></canvas>
     <script>
       function assert(condition) {
-        if (!condition) console.error(...Array.from(arguments).slice(1));
+        if (!condition) console.error('ASSERTION FAILURE:', ...Array.from(arguments).slice(1));
       }
 
-      const leverage = 100;
-      const resolution = 5;
+      const leverage = 150;
+      const resolution = 100;
+      assert(resolution >= 2, 'Must use a curve resolution of 2 or higher')
       const points = Array(resolution).fill(leverage);
 
       function updatePoint(idx, diff) {
@@ -89,7 +90,7 @@
         }
 
         avg = points.reduce((i, t) => i+t, 0) / points.length;
-        assert(avg === leverage, 'Points in invalid state', points, avg);
+        assert(avg.toFixed(2) === leverage.toFixed(2), 'Points in invalid state', points, avg);
 
         drawCurve();
       }

--- a/index.html
+++ b/index.html
@@ -245,13 +245,16 @@
             strokep,
           } = variables[i];
 
+          console.log('iteration', i);
+
           function getVal(x) {
             let value = (m*x) - (m*Y) + Math.log((m*X)+b) - Math.log((k*x) / (w*r));
+            console.log(m,b,x,X,Y,w,r);
             return value;
           }
 
           function getDer(x) {
-            return -1/x;
+            return m-1/x;
           }
 
           let inspecting = strokeq || 1/Number.MAX_SAFE_INTEGER;  // prevent /0 error when getting dir
@@ -265,7 +268,7 @@
             const dir = getDer(inspecting);
             inspecting -= lastValue/dir;
             // TODO: try to adjust this to return the instable states exactly
-            if (isNaN(inspecting)) return NaN;
+            // if (isNaN(inspecting)) return NaN;
           }
 
           if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {

--- a/index.html
+++ b/index.html
@@ -177,18 +177,51 @@
           return ret;
         });
 
+        console.log(strokeLineFuncs);
+
         return strokeLineFuncs;
       }
 
       function updatePoint(idx, diff) {
         points[idx] += diff;
-        for (let i = 0; i < points.length; i++) {
-          if (i === idx) continue;
-          points[i] -= diff/(points.length-1);
+
+        const targetArea = resolution-1;
+
+        let area = 0;
+        for (let i = 0; i < points.length-1; i++) {
+          const x0 = i;
+          const x1 = i+1;
+          const y0 = points[i];
+          const y1 = points[i+1];
+          const m = (y1-y0)/(x1-x0);
+          const b = y0-(m*x0);
+          const q = x0;
+          const p = x1;
+          area += ((m*(Math.pow(p,2) - Math.pow(q,2)))/2) + (b*p) - (b*q)
         }
 
-        avg = points.reduce((i, t) => i+t, 0) / points.length;
-        console.assert(avg.toFixed(2) == 1, 'Points in invalid state', points, avg);
+        const perPointDiff = (targetArea - area)/(resolution-1);
+
+        for (let i = 0; i < points.length; i++) {
+          // need to update each one to retain the area under the curve
+          points[i] += perPointDiff;
+        }
+
+        // TODO: only do verifacation like this when deving
+        area = 0;
+        for (let i = 0; i < points.length-1; i++) {
+          const x0 = i;
+          const x1 = i+1;
+          const y0 = points[i];
+          const y1 = points[i+1];
+          const m = (y1-y0)/(x1-x0);
+          const b = y0-(m*x0);
+          const q = x0;
+          const p = x1;
+          area += ((m*(Math.pow(p,2) - Math.pow(q,2)))/2) + (b*p) - (b*q)
+        }
+        console.assert(area < targetArea+0.1, 'Points in invalid state', area, targetArea);
+        console.assert(area > targetArea-0.1, 'Points in invalid state', area, targetArea);
 
         getVariables();
         drawCurve();
@@ -197,7 +230,6 @@
 
       function findRoot(variables, k, w, r) {
         for (let i = 0; i < variables.length; i++) {
-          console.log('variable', variables[i]);
           const {
             m,
             b,
@@ -226,8 +258,6 @@
             const dir = getDer(inspecting);
             inspecting -= lastValue/dir;
           }
-
-          console.log('iteration count', iteration);
 
           // TODO: consider making the top end unbounded for the last func (related to other todo)
           if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {
@@ -405,7 +435,6 @@
 
         // This is what we need to swap out
         sag = findRoot(variables, springWeight, riderWeight, rearTireBias);
-        console.log('the final sag', sag);
 
         sag *= 25.4 // mm
         sag /= stroke / 100 // %

--- a/index.html
+++ b/index.html
@@ -78,12 +78,14 @@
       }
 
       const leverage = 150;
-      const resolution = 100;
-      assert(resolution >= 2, 'Must use a curve resolution of 2 or higher')
+      const resolution = 6;
+      assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
       const points = Array(resolution).fill(leverage);
 
       function updatePoint(idx, diff) {
-        points[idx] += diff
+        points[idx] += diff;
+        const impactWidth = 20;
+        // get the number of nodes we have available around the index within the imapct width
         for (let i = 0; i < points.length; i++) {
           if (i === idx) continue;
           points[i] -= diff/(points.length-1);
@@ -113,17 +115,49 @@
       }
 
       function drawCurve() {
+        // i think this is how i want to smooth the curve
+        // https://en.wikipedia.org/wiki/Cubic_Hermite_spline
+
+        // use finite difference to calculate the slopes at each point
+        let slopes = [];
+        for (let i = 0; i < points.length; i++) {
+          // NOTE: that our points are uniformly spaces right now to all our runs are just set to 1 for simplicity
+          let partials = [];
+          if (i > 0) {
+            partials.push((points[i]-points[i-1])/1);
+          }
+          if (i < points.length-1) {
+            partials.push((points[i+1]-points[i])/1);
+          }
+          slopes[i] = (1/partials.length)*(partials.reduce((x,y) => x+y, 0));
+        }
+
         function getY(y) {
           return curveHeight - y;
         }
+
+        const segmentWidth = curveWidth/(resolution-1);
         curveContext.clearRect(0, 0, curveWidth, curveHeight);
         curveContext.beginPath();
         curveContext.lineWidth = 2;
         curveContext.strokeStyle = '#000';
         curveContext.moveTo(0, getY(points[0]));
-        for (let i = 1; i < points.length; i++) {
-          const val = points[i];
-          curveContext.lineTo((curveWidth/(resolution-1)) * (i), getY(val));
+        let lastmod = 0;
+        for (let i = 1; i <= curveWidth; i++) {
+          const index = Math.floor(i/segmentWidth);
+          const mod = i%segmentWidth;
+          // cannot use === 0 because of precision issues
+          if (mod < lastmod || i === curveWidth) { 
+            curveContext.lineTo(i, getY(points[index]));
+          }
+          lastmod = mod;
+
+          // this is when we need to interpolate
+          const p0 = points[index], p1 = points[index+1], m0 = slopes[index], m1 = slopes[index+1];
+          function inter(t) {
+            return ((2*t**3 - 3*t**2 + 1)*p0) + ((t**3 - 2*t**2 + t)*m0) + ((-2*t**3 + 3*t**2)*p1) + ((t**3 - t**2)*m1);
+          }
+          curveContext.lineTo(i, getY(inter(mod/segmentWidth)));
         }
         curveContext.stroke();
       }

--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
       let normWeight;
       let wheelTravel;
       let stroke;
+      let sag;
       let springWeight;
       let simulating = false;
       let acc = 0;
@@ -286,7 +287,7 @@
         const leverage = wheelTravel / stroke;
         // TODO: add in (part of) average weight of the bike itself?
         const rearTireBias = 0.65; // the rear wheel supports 65% of the riders weight
-        const adjustedRiderWeight = riderWeight * rearTireBias;
+        normWeight = riderWeight  * leverage * rearTireBias;
 
         // hooks law to solve for the spring rate
         // F = k*x
@@ -294,17 +295,7 @@
         // k   spring rate
         // x   deformation (sometimes called displacement)
 
-        function momentaryLeverage(strokeX) {
-          // NOTE: that the curves we create give us information in travelX not strokeX
-          // so we are going to have to do some converting or figuring
-          return leverage + (2*strokeX);
-        }
-
-        // the leverage equation solved
-        let sag = adjustedRiderWeight * leverage / (springWeight - (2*adjustedRiderWeight)); // in
-        console.log('sag in in', sag);
-        normWeight = adjustedRiderWeight * momentaryLeverage(sag);
-        console.log('the norm weight', normWeight);
+        sag = normWeight / springWeight; // in
         sag *= 25.4 // mm
         sag /= stroke / 100 // %
         sag = Math.round(sag * 100) / 100; // round to 2 decimals (so users can see something is changing
@@ -585,8 +576,6 @@
         const forces = [];
         let springConstant = springWeight * 4.448; // N/in
         springConstant = springConstant / 25.4; // N/mm
-        // TODO: we should not reference norm weight as a constant but should
-        // recalculate based on the leverage curve (can use the pos)
         let weight = normWeight * 4.448; // N
 
         forces.push(simulating ? weight : 0);

--- a/index.html
+++ b/index.html
@@ -455,7 +455,9 @@
 
         sag *= 25.4 // mm
         sag /= stroke / 100 // %
-        sag = Math.round(sag * 100) / 100; // round to 2 decimals (so users can see something is changing
+        // Do a math.min incase our leverage curve estimate is a little off and would
+        // lead to max sag at like 99.9 or 100.1 or something
+        sag = Math.min(Math.round(sag * 100) / 100, 100); // round to 2 decimals (so users can see something is changing
         document.getElementById('sag-output').innerHTML = sag;
 
         document.querySelectorAll('[data-sag]').forEach(el => {

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         curveContext.scale(window.devicePixelRatio, window.devicePixelRatio);  
       }
 
-      function drawCurve() {
+      function curveCubics() {
         // i think this is how i want to smooth the curve
         // https://en.wikipedia.org/wiki/Cubic_Hermite_spline
 
@@ -131,11 +131,23 @@
           }
           slopes[i] = (1/partials.length)*(partials.reduce((x,y) => x+y, 0));
         }
-
-        function getY(y) {
-          return scale*(maxLeverageMultiplier) - (y*scale);
+        let funcs = [];
+        for (let i = 0; i < points.length-1; i++) {
+          // this is when we need to interpolate
+          const p0 = points[i], p1 = points[i+1], m0 = slopes[i], m1 = slopes[i+1];
+          funcs.push(function inter(t) {
+            return ((2*t**3 - 3*t**2 + 1)*p0) + ((t**3 - 2*t**2 + t)*m0) + ((-2*t**3 + 3*t**2)*p1) + ((t**3 - t**2)*m1);
+          })
         }
+        return funcs;
+      }
 
+      function getY(y) {
+        return scale*(maxLeverageMultiplier) - (y*scale);
+      }
+
+      function drawCurve() {
+        const curves = curveCubics();
         const segmentWidth = curveWidth/(resolution-1);
         curveContext.clearRect(0, 0, curveWidth, curveHeight);
         curveContext.beginPath();
@@ -143,21 +155,17 @@
         curveContext.strokeStyle = '#000';
         curveContext.moveTo(0, getY(points[0]));
         let lastmod = 0;
-        for (let i = 1; i <= curveWidth; i++) {
+        for (let i = 1; i < curveWidth; i++) {
           const index = Math.floor(i/segmentWidth);
           const mod = i%segmentWidth;
           // cannot use === 0 because of precision issues
           if (mod < lastmod || i === curveWidth) { 
             curveContext.lineTo(i, getY(points[index]));
+            lastmod = mod;
+            continue;
           }
           lastmod = mod;
-
-          // this is when we need to interpolate
-          const p0 = points[index], p1 = points[index+1], m0 = slopes[index], m1 = slopes[index+1];
-          function inter(t) {
-            return ((2*t**3 - 3*t**2 + 1)*p0) + ((t**3 - 2*t**2 + t)*m0) + ((-2*t**3 + 3*t**2)*p1) + ((t**3 - t**2)*m1);
-          }
-          curveContext.lineTo(i, getY(inter(mod/segmentWidth)));
+          curveContext.lineTo(i, getY(curves[index](mod/segmentWidth)));
         }
         curveContext.stroke();
       }

--- a/index.html
+++ b/index.html
@@ -71,60 +71,28 @@
     </style>
   </head>
   <body>
-    <div>
-      <label>
-        Average ratio
-        <input type="number" value="0" />
-      </label>
-      <label>
-        Curve point 1
-        <input type="number" value="0" />
-      </label>
-      <label>
-        Curve point 2
-        <input type="number" value="0" />
-      </label>
-      <label>
-        Curve point 3
-        <input type="number" value="0" />
-      </label>
-      <label>
-        Curve point 4
-        <input type="number" value="0" />
-      </label>
-      <label>
-        Curve point 5
-        <input type="number" value="0" />
-      </label>
-    </div>
     <canvas id="curve"></canvas>
     <script>
-      const inputs = Array.from(document.querySelectorAll('input[type="number"]'));
-      const averageInput = inputs[0];
-      const pointInputs = inputs.slice(1, 6);
+      function assert(condition) {
+        if (!condition) console.error(...Array.from(arguments).slice(1));
+      }
 
-      averageInput.addEventListener('change', function(event) {
-        const avg = pointInputs.reduce((t, i) => parseFloat(i.value || 0) + t, 0) / pointInputs.length; 
-        const diff = parseFloat(event.target.value) - avg;
-        pointInputs.forEach(i => {
-          i.value = parseFloat(i.value) + diff;
-        });
+      const leverage = 100;
+      const resolution = 5;
+      const points = Array(resolution).fill(leverage);
+
+      function updatePoint(idx, diff) {
+        points[idx] += diff
+        for (let i = 0; i < points.length; i++) {
+          if (i === idx) continue;
+          points[i] -= diff/(points.length-1);
+        }
+
+        avg = points.reduce((i, t) => i+t, 0) / points.length;
+        assert(avg === leverage, 'Points in invalid state', points, avg);
+
         drawCurve();
-      });
-
-      pointInputs.forEach(input => {
-        input.addEventListener('change', function(event) {
-          const total = pointInputs.reduce((t, i) => parseFloat(i.value || 0) + t, 0); 
-          const avgTotal = parseFloat(averageInput.value) * pointInputs.length;
-          const diffTotal = avgTotal - total;
-          // TODO: distribute proportionally based on the index we are changing
-          pointInputs.forEach(i => {
-            if (i === input) return;
-            i.value = parseFloat(i.value) + (diffTotal/(pointInputs.length-1));
-          });
-          drawCurve();
-        });
-      });
+      }
 
       // Animation stuff
       const curveCanvas = document.querySelector('canvas#curve');
@@ -151,10 +119,10 @@
         curveContext.beginPath();
         curveContext.lineWidth = 2;
         curveContext.strokeStyle = '#000';
-        curveContext.moveTo(100, getY(pointInputs[0].value));
-        for (let i = 1; i < pointInputs.length; i++) {
-          const inp = pointInputs[i];
-          curveContext.lineTo(100 * (i + 1), getY(inp.value));
+        curveContext.moveTo(0, getY(points[0]));
+        for (let i = 1; i < points.length; i++) {
+          const val = points[i];
+          curveContext.lineTo((curveWidth/(resolution-1)) * (i), getY(val));
         }
         curveContext.stroke();
       }
@@ -166,19 +134,17 @@
       curveCanvas.addEventListener('mousemove', function(event) {
         y = event.clientY;
         x = event.clientX;
-        if (currentX == null) return;
-        pointInputs[currentX].value = parseFloat(pointInputs[currentX].value) + (prevY - y);
-        pointInputs[currentX].dispatchEvent(new Event('change'));
+        if (prevY == null) return;
+        updatePoint(currentX, prevY-y)
         prevY = y;
       });
       curveCanvas.addEventListener('mousedown', function(event) {
         prevY = y;
-        const i = Math.round(x/100)-1;
-        if (i >= 0 && i < pointInputs.length) currentX = i;
+        const i = Math.round(x/(curveWidth/resolution));
+        if (i >= 0 && i < points.length) currentX = i;
       });
       curveCanvas.addEventListener('mouseup', function(event) {
         prevY = null;
-        currentX = null;
       });
 
     </script>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,8 @@
         box-shadow:0 0px 0 5px #f07909;
       }
       button span {font-size:1.5em;font-weight:700;}
-      form > * {
+      form > *,
+      form > details > label{
         width:100%;
         display:flex;
         margin-bottom:1rem;
@@ -93,12 +94,16 @@
         }
       }
 
+      details > summary {
+        margin-bottom: 1rem;
+      }
+
       .curve-container {
         padding-left: 40px;
         padding-right: 20px;
         padding-bottom: 30px;
         position: relative;
-        margin: 0 1rem 3rem;
+        margin: 1rem 0;
       }
       .curve-container > span:not(.x-axis) {
         position: absolute;
@@ -138,9 +143,9 @@
       .curve-heading {
         font-size: 1rem;
         text-align: center;
+        margin-top: 1.5em;
         margin-bottom: 1em;
       }
-
 
       #curve {
         border: 1px solid #eaeaea;
@@ -173,24 +178,31 @@
             <input type="number" name="stroke" value="60">
           </label>
           <label>
-            <strong>Spring Weight (lbs/in)</strong>
+            Spring Weight (lbs/in)
             <input type="number" name="spring-weight" value="400">
           </label>
+          <details>
+            <summary>Advanced Settings (optional)</summary>
+            <label>
+              <span>Rear Wheel Bias (default 65%)</span>
+              <input type="number" name="rear-bias" value="65">
+            </label>
+            <h2 class="curve-heading">Leverage Curve</h2>
+            <div class="curve-container">
+              <span id="double-leverage">2</span>
+              <span id="base-leverage">1</span>
+              <span>0</span>
+              <span id="wheel-travel-label">1</span>
+              <span class="x-axis">Wheel Travel</span>
+              <canvas id="curve"></canvas>
+            </div>
+          </details>
+
           <div>
-            <strong>Calculated Sag</strong>
+            <strong style="font-size:1.2rem;">Calculated Sag</strong>
             <span style="font-size:1.5rem;"><span id="sag-output"></span>% *</span>
           </div>
         </form>
-
-        <h2 class="curve-heading">Leverage Curve</h2>
-        <div class="curve-container">
-          <span id="double-leverage">2</span>
-          <span id="base-leverage">1</span>
-          <span>0</span>
-          <span id="wheel-travel-label">1</span>
-          <span class="x-axis">Wheel Travel</span>
-          <canvas id="curve"></canvas>
-        </div>
 
         <footer style="text-align:center;padding: 20px;">View code and license on <a href="https://github.com/RyanBerliner/coil-calculator">GitHub</a></footer>
       </div>
@@ -485,6 +497,7 @@
       const wheelTravelLabel = document.getElementById('wheel-travel-label');
 
       let riderWeight;
+      let rearTireBias;
       let normWeight;
       let sag;
       let springWeight;
@@ -535,6 +548,16 @@
 
       function calculateCharacteristics() {
         const data = new FormData(form);
+        rearTireBias = parseInt(data.get('rear-bias') || 65);
+        if (rearTireBias<=0) {
+          rearTireBias = 1;
+          form.querySelector('[name="rear-bias"]').value = 1;
+        }
+        if (rearTireBias>=99) {
+          rearTireBias = 99;
+          form.querySelector('[name="rear-bias"]').value = 99;
+        }
+        rearTireBias /= 100;
         riderWeight = parseInt(data.get('rider-weight') || 0);
         wheelTravel = parseInt(data.get('travel') || 0);
         stroke = parseInt(data.get('stroke') || 1);
@@ -547,7 +570,6 @@
         variables = getVariables();
 
         // TODO: add in (part of) average weight of the bike itself?
-        const rearTireBias = 0.65; // the rear wheel supports 65% of the riders weight
         normWeight = riderWeight * rearTireBias;
 
         // hooks law to solve for the spring rate

--- a/index.html
+++ b/index.html
@@ -86,16 +86,9 @@
       assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
       const points = Array(resolution).fill(1);
 
-      function makeSolvers() {
-        // TODO: remove the static values here & reference the globals
-        //       that are set in the shock specs
-        let travel = 160;
-        let stroke = 60;
+      function getVariables(travel, stroke) {
         const baseLeverage = travel/stroke;
         const piecewiseRange = travel / (resolution-1);
-        console.log('base leverage', baseLeverage);
-        console.log('piecewise range', piecewiseRange);
-        console.log('points', points);
 
         const travelLineFuncs = [];
         for (let i = 0; i < points.length-1; i++) {
@@ -112,12 +105,11 @@
             p: x1, // consider setting to inf (or undefined) for last point?)
           });
         }
-        console.log('travel line funcs', travelLineFuncs);
 
         let X = 0;
         let Y = 0;
         const strokeLineFuncs = travelLineFuncs.map(({m, b, q, p}) => {
-          const ret =  {
+          const ret = {
             m,
             b,
             X,
@@ -125,16 +117,15 @@
             q,
             p,
             // these are actually "stroke" q, p
-            newq: (q/(m*q+b))-(X/(m*X+b))+Y,
-            newp: (p/(m*p+b))-(X/(m*X+b))+Y,
+            strokeq: (q/(m*q+b))-(X/(m*X+b))+Y,
+            strokep: (p/(m*p+b))-(X/(m*X+b))+Y,
           }
           Y = (p/(m*p+b))-(X/(m*X+b))+Y
           X = p;
           return ret;
         });
 
-        console.log('stroke line funcs', strokeLineFuncs);
-
+        return strokeLineFuncs;
       }
 
       function updatePoint(idx, diff) {
@@ -147,8 +138,49 @@
         avg = points.reduce((i, t) => i+t, 0) / points.length;
         assert(avg.toFixed(2) == 1, 'Points in invalid state', points, avg);
 
-        makeSolvers();
+        getVariables();
         drawCurve();
+      }
+
+      function findRoot(variables, k, w, r) {
+        for (let i = 0; i < variables.length; i++) {
+          console.log('variable', variables[i]);
+          const {
+            m,
+            b,
+            X,
+            Y,
+            strokeq,
+            strokep,
+          } = variables[i];
+
+          function getVal(x) {
+            return (m*x) - (m*Y) + Math.log((m*X)+b) - Math.log((k*x) / (w*r));
+          }
+
+          function getDer(x) {
+            return -1/x;
+          }
+
+          let inspecting = strokeq || 1/Number.MAX_SAFE_INTEGER;  // prevent /0 error when getting dir
+          let iteration = 0;
+          let lastValue = undefined;
+          const foundRoot = () => lastValue > -0.000001 && lastValue < 0.000001;
+          // this is newtons method https://en.wikipedia.org/wiki/Newton's_method
+          while (iteration < 1000 && !foundRoot()) {
+            iteration++;
+            lastValue = getVal(inspecting);
+            const dir = getDer(inspecting);
+            inspecting -= lastValue/dir;
+          }
+
+          console.log('iteration count', iteration);
+
+          if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {
+            return inspecting;
+          }
+        }
+        return 0;
       }
 
       // Animation stuff
@@ -222,7 +254,7 @@
         curveContext.stroke();
       }
 
-      makeSolvers();
+      getVariables();
       drawCurve();
 
       // canvas interaction
@@ -345,10 +377,11 @@
         stroke = parseInt(data.get('stroke') || 1);
         springWeight = parseInt(data.get('spring-weight') || 0);
 
-        const leverage = wheelTravel / stroke;
+        const variables = getVariables(wheelTravel / 25.4, stroke / 25.4);
+
         // TODO: add in (part of) average weight of the bike itself?
         const rearTireBias = 0.65; // the rear wheel supports 65% of the riders weight
-        normWeight = riderWeight  * leverage * rearTireBias;
+        normWeight = riderWeight * rearTireBias;
 
         // hooks law to solve for the spring rate
         // F = k*x
@@ -356,7 +389,11 @@
         // k   spring rate
         // x   deformation (sometimes called displacement)
 
-        sag = normWeight / springWeight; // in
+
+        // This is what we need to swap out
+        sag = findRoot(variables, springWeight, riderWeight, rearTireBias);
+        console.log('the final sag', sag);
+
         sag *= 25.4 // mm
         sag /= stroke / 100 // %
         sag = Math.round(sag * 100) / 100; // round to 2 decimals (so users can see something is changing

--- a/index.html
+++ b/index.html
@@ -196,6 +196,7 @@
 
         getVariables();
         drawCurve();
+        calculateCharacteristics();
       }
 
       function findRoot(variables, k, w, r) {

--- a/index.html
+++ b/index.html
@@ -234,7 +234,6 @@
       let normWeight;
       let wheelTravel;
       let stroke;
-      let sag;
       let springWeight;
       let simulating = false;
       let acc = 0;
@@ -287,7 +286,7 @@
         const leverage = wheelTravel / stroke;
         // TODO: add in (part of) average weight of the bike itself?
         const rearTireBias = 0.65; // the rear wheel supports 65% of the riders weight
-        normWeight = riderWeight  * leverage * rearTireBias;
+        const adjustedRiderWeight = riderWeight * rearTireBias;
 
         // hooks law to solve for the spring rate
         // F = k*x
@@ -295,7 +294,17 @@
         // k   spring rate
         // x   deformation (sometimes called displacement)
 
-        sag = normWeight / springWeight; // in
+        function momentaryLeverage(strokeX) {
+          // NOTE: that the curves we create give us information in travelX not strokeX
+          // so we are going to have to do some converting or figuring
+          return leverage + (2*strokeX);
+        }
+
+        // the leverage equation solved
+        let sag = adjustedRiderWeight * leverage / (springWeight - (2*adjustedRiderWeight)); // in
+        console.log('sag in in', sag);
+        normWeight = adjustedRiderWeight * momentaryLeverage(sag);
+        console.log('the norm weight', normWeight);
         sag *= 25.4 // mm
         sag /= stroke / 100 // %
         sag = Math.round(sag * 100) / 100; // round to 2 decimals (so users can see something is changing
@@ -576,6 +585,8 @@
         const forces = [];
         let springConstant = springWeight * 4.448; // N/in
         springConstant = springConstant / 25.4; // N/mm
+        // TODO: we should not reference norm weight as a constant but should
+        // recalculate based on the leverage curve (can use the pos)
         let weight = normWeight * 4.448; // N
 
         forces.push(simulating ? weight : 0);

--- a/index.html
+++ b/index.html
@@ -264,6 +264,8 @@
             lastValue = getVal(inspecting);
             const dir = getDer(inspecting);
             inspecting -= lastValue/dir;
+            // TODO: try to adjust this to return the instable states exactly
+            if (isNaN(inspecting)) return NaN;
           }
 
           if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {
@@ -271,7 +273,7 @@
           }
         }
 
-        return NaN;
+        return variables[variables.length-1].strokep;
       }
 
       // Animation stuff

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
       console.assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
       const points = Array(resolution).fill(1);
 
+      let variables = getVariables();  // really need a better name for this
       function getVariables() {
         const baseLeverage = wheelTravel/stroke;
         const piecewiseRange = wheelTravel / 25.4 / (resolution-1);
@@ -230,7 +231,7 @@
           }
         }
 
-        getVariables();
+        variables = getVariables();
         drawCurve();
         calculateCharacteristics();
       }
@@ -345,7 +346,6 @@
         curveContext.stroke();
       }
 
-      getVariables();
       drawCurve();
 
       // canvas interaction
@@ -420,7 +420,6 @@
       }
 
       function leverageOfShockAtStroke(s) {
-        const variables = getVariables(); 
         for (let i = 0; i < variables.length; i++) {
           const {strokeq, strokep, m, Y, X, b} = variables[i];
           if (s < strokep && s >= strokeq) {
@@ -438,7 +437,7 @@
         stroke = parseInt(data.get('stroke') || 1);
         springWeight = parseInt(data.get('spring-weight') || 0);
 
-        const variables = getVariables();
+        variables = getVariables();
 
         // TODO: add in (part of) average weight of the bike itself?
         const rearTireBias = 0.65; // the rear wheel supports 65% of the riders weight

--- a/index.html
+++ b/index.html
@@ -100,34 +100,47 @@
         position: relative;
         margin: 0 1rem 3rem;
       }
-      .curve-container > span {
+      .curve-container > span:not(.x-axis) {
+        position: absolute;
         text-align: right;
         display: inline-block;
         width: 30px;
       }
       .curve-container > span:nth-child(1) {
-        position: absolute;
         top: 0;
         transform: translateY(-50%);
         left: 0;
       }
       .curve-container > span:nth-child(2) {
-        position: absolute;
         top: calc(50% - 15px);
         transform: translateY(-50%);
         left: 0;
       }
       .curve-container > span:nth-child(3) {
-        position: absolute;
         bottom: 0;
         left: 0;
       }
       .curve-container > span:nth-child(4) {
-        position: absolute;
         bottom: 0;
         right: 20px;
         transform: translateX(50%);
       }
+      .x-axis {
+        position: absolute;
+        transform: translateX(-50%);
+        bottom: 0;
+        left: 50%;
+        font-size: 0.7em;
+        opacity: 0.5;
+        text-transform: uppercase;
+        font-weight: bold;
+      }
+      .curve-heading {
+        font-size: 1rem;
+        text-align: center;
+        margin-bottom: 1em;
+      }
+
 
       #curve {
         border: 1px solid #eaeaea;
@@ -169,11 +182,13 @@
           </div>
         </form>
 
+        <h2 class="curve-heading">Leverage Curve</h2>
         <div class="curve-container">
           <span id="double-leverage">2</span>
           <span id="base-leverage">1</span>
           <span>0</span>
           <span id="wheel-travel-label">1</span>
+          <span class="x-axis">Wheel Travel</span>
           <canvas id="curve"></canvas>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -109,10 +109,7 @@
             <input type="number" name="stroke" value="60">
           </label>
           <label>
-            <span>
-              <strong>Spring Weight (lbs/in)</strong><br/>
-              Reset to 30% sag using <a href="#" data-sag="30"></a>
-            </span>
+            <strong>Spring Weight (lbs/in)</strong>
             <input type="number" name="spring-weight" value="400">
           </label>
           <div>
@@ -412,13 +409,6 @@
         }
       });
 
-      function getSpringWeight(sagAmount) {
-        const targetSagDistance = stroke * sagAmount / 100;
-        let weight = normWeight / targetSagDistance; // lbs/mm
-        weight *= 25.4 // lbs/in
-        return parseInt(weight);
-      }
-
       function leverageOfShockAtStroke(s) {
         for (let i = 0; i < variables.length; i++) {
           const {strokeq, strokep, m, Y, X, b} = variables[i];
@@ -457,14 +447,8 @@
         sag /= stroke / 100 // %
         // Do a math.min incase our leverage curve estimate is a little off and would
         // lead to max sag at like 99.9 or 100.1 or something
-        sag = Math.min(Math.round(sag * 100) / 100, 100); // round to 2 decimals (so users can see something is changing
+        sag = Math.min(Math.round(sag * 100) / 100, 100).toFixed(2); // round to 2 decimals (so users can see something is changing
         document.getElementById('sag-output').innerHTML = sag;
-
-        document.querySelectorAll('[data-sag]').forEach(el => {
-          const weight = getSpringWeight(parseInt(el.getAttribute('data-sag')));
-          el.innerHTML = weight + ' lbs/in';
-          el.setAttribute('data-val', weight);
-        });
       }
 
       calculateCharacteristics();

--- a/index.html
+++ b/index.html
@@ -71,6 +71,60 @@
     </style>
   </head>
   <body>
+    <div>
+      <label>
+        Average ratio
+        <input type="number" value="0" />
+      </label>
+      <label>
+        Curve point 1
+        <input type="number" value="0" />
+      </label>
+      <label>
+        Curve point 2
+        <input type="number" value="0" />
+      </label>
+      <label>
+        Curve point 3
+        <input type="number" value="0" />
+      </label>
+      <label>
+        Curve point 4
+        <input type="number" value="0" />
+      </label>
+      <label>
+        Curve point 5
+        <input type="number" value="0" />
+      </label>
+    </div>
+    <script>
+      const inputs = Array.from(document.querySelectorAll('input[type="number"]'));
+      const averageInput = inputs[0];
+      const pointInputs = inputs.slice(1, 6);
+
+      averageInput.addEventListener('change', function(event) {
+        const avg = pointInputs.reduce((t, i) => parseFloat(i.value || 0) + t, 0) / pointInputs.length; 
+        const diff = parseFloat(event.target.value) - avg;
+        pointInputs.forEach(i => {
+          i.value = parseFloat(i.value) + diff;
+        });
+      });
+
+      pointInputs.forEach(input => {
+        input.addEventListener('change', function(event) {
+          const total = pointInputs.reduce((t, i) => parseFloat(i.value || 0) + t, 0); 
+          const avgTotal = parseFloat(averageInput.value) * pointInputs.length;
+          const diffTotal = avgTotal - total;
+          // TODO: distribute proportionally based on the index we are changing
+          pointInputs.forEach(i => {
+            if (i === input) return;
+            i.value = parseFloat(i.value) + (diffTotal/(pointInputs.length-1));
+          });
+        });
+      });
+      
+    </script>
+
     <canvas></canvas>
     <button id="simulate"><span>Press & Hold</span><br/>to visualize sag</button>
     <form>

--- a/index.html
+++ b/index.html
@@ -128,18 +128,14 @@
     </div>
 
     <script>
-      function assert(condition) {
-        if (!condition) console.error('ASSERTION FAILURE:', ...Array.from(arguments).slice(1));
-      }
-
       const curveCanvas = document.querySelector('canvas#curve');
       const curveHeight = window.outerHeight / 3;
       const curveWidth = curveCanvas.parentElement.offsetWidth;
 
-      const resolution = 3;
+      const resolution = 6;
       const maxLeverageMultiplier = 2;
       const scale = curveHeight / maxLeverageMultiplier;
-      assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
+      console.assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
       const points = Array(resolution).fill(1);
 
       function getVariables(travel, stroke) {
@@ -192,7 +188,7 @@
         }
 
         avg = points.reduce((i, t) => i+t, 0) / points.length;
-        assert(avg.toFixed(2) == 1, 'Points in invalid state', points, avg);
+        console.assert(avg.toFixed(2) == 1, 'Points in invalid state', points, avg);
 
         getVariables();
         drawCurve();

--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@
 
           console.log('iteration count', iteration);
 
+          // TODO: consider making the top end unbounded for the last func (related to other todo)
           if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {
             return inspecting;
           }

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
 
       .curve-container {
         padding-left: 40px;
+        padding-right: 20px;
         padding-bottom: 30px;
         position: relative;
         margin: 0 1rem 3rem;
@@ -124,7 +125,7 @@
       .curve-container > span:nth-child(4) {
         position: absolute;
         bottom: 0;
-        right: 0;
+        right: 20px;
         transform: translateX(50%);
       }
 
@@ -185,7 +186,7 @@
       let stroke;
       const curveCanvas = document.querySelector('canvas#curve');
       const curveHeight = 200;
-      const curveWidth = curveCanvas.parentElement.offsetWidth-40;
+      const curveWidth = curveCanvas.parentElement.offsetWidth-40-20;
 
       const resolution = 6;
       const maxLeverageMultiplier = 2;

--- a/index.html
+++ b/index.html
@@ -245,11 +245,8 @@
             strokep,
           } = variables[i];
 
-          console.log('iteration', i);
-
           function getVal(x) {
             let value = (m*x) - (m*Y) + Math.log((m*X)+b) - Math.log((k*x) / (w*r));
-            console.log(m,b,x,X,Y,w,r);
             return value;
           }
 
@@ -267,8 +264,6 @@
             lastValue = getVal(inspecting);
             const dir = getDer(inspecting);
             inspecting -= lastValue/dir;
-            // TODO: try to adjust this to return the instable states exactly
-            // if (isNaN(inspecting)) return NaN;
           }
 
           if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {

--- a/index.html
+++ b/index.html
@@ -161,6 +161,8 @@
         let X = 0;
         let Y = 0;
         const strokeLineFuncs = travelLineFuncs.map(({m, b, q, p}) => {
+          // the problem to solve is that if m === 0 this is undefined. need to find value as m approaches m
+          const yValueAtPofIntegral = ((Math.log(m*p+b)-Math.log(m*q+b))/m)+Y;
           const ret = {
             m,
             b,
@@ -169,10 +171,11 @@
             q,
             p,
             // these are actually "stroke" q, p
-            strokeq: (q/(m*q+b))-(X/(m*X+b))+Y,
-            strokep: (p/(m*p+b))-(X/(m*X+b))+Y,
+            // i think that these are wrong
+            strokeq: Y,// y value at integral of p
+            strokep: yValueAtPofIntegral, // y value at integral of q
           }
-          Y = (p/(m*p+b))-(X/(m*X+b))+Y
+          Y = yValueAtPofIntegral;
           X = p;
           return ret;
         });
@@ -185,7 +188,7 @@
       function updatePoint(idx, diff) {
         points[idx] += diff;
 
-        const targetArea = resolution-1;
+        const targetArea = resolution-1; // the target area of our inverse
 
         let area = 0;
         for (let i = 0; i < points.length-1; i++) {
@@ -197,18 +200,17 @@
           const b = y0-(m*x0);
           const q = x0;
           const p = x1;
-          area += ((m*(Math.pow(p,2) - Math.pow(q,2)))/2) + (b*p) - (b*q)
+          // find the area under the inverse (the actual derivitive)
+          if (m === 0) { // becuase of the problem if this is the case then b will not be 0 so OK
+            area += (p-q)/b
+          } else {
+            area += (Math.log((m*p)+b)-Math.log((m*q)+b))/m
+          }
         }
 
-        const perPointDiff = (targetArea - area)/(resolution-1);
+        const perPointDiff = (targetArea-area)/(resolution-1);
+        console.log('area, diff', area, perPointDiff);
 
-        for (let i = 0; i < points.length; i++) {
-          // need to update each one to retain the area under the curve
-          points[i] += perPointDiff;
-        }
-
-        // TODO: only do verifacation like this when deving
-        area = 0;
         for (let i = 0; i < points.length-1; i++) {
           const x0 = i;
           const x1 = i+1;
@@ -218,10 +220,30 @@
           const b = y0-(m*x0);
           const q = x0;
           const p = x1;
-          area += ((m*(Math.pow(p,2) - Math.pow(q,2)))/2) + (b*p) - (b*q)
+
+          const recip = x => (1/(m*x+b))+perPointDiff;
+          points[i] = 1/recip(q);
+          if ((i+1) === (points.length-1)) {
+            const end = recip(p);
+            points[i+1] = 1/recip(p);
+          }
         }
-        console.assert(area < targetArea+0.1, 'Points in invalid state', area, targetArea);
-        console.assert(area > targetArea-0.1, 'Points in invalid state', area, targetArea);
+
+        // TODO: only do verifacation like this when deving
+        // area = 0;
+        // for (let i = 0; i < points.length-1; i++) {
+        //   const x0 = i;
+        //   const x1 = i+1;
+        //   const y0 = 1/points[i];
+        //   const y1 = 1/points[i+1];
+        //   const m = (y1-y0)/(x1-x0);
+        //   const b = y0-(m*x0);
+        //   const q = x0;
+        //   const p = x1;
+        //   area += ((m*(Math.pow(p,2) - Math.pow(q,2)))/2) + (b*p) - (b*q)
+        // }
+        // console.assert(area < targetArea+0.1, 'Points in invalid state', area, targetArea);
+        // console.assert(area > targetArea-0.1, 'Points in invalid state', area, targetArea);
 
         getVariables();
         drawCurve();

--- a/index.html
+++ b/index.html
@@ -117,16 +117,18 @@
         let X = 0;
         let Y = 0;
         const strokeLineFuncs = travelLineFuncs.map(({m, b, q, p}) => {
-          const domainEnd = (p/(m*p+b))-(X/(m*X+b))+Y;
           const ret =  {
             m,
             b,
             X,
             Y,
-            q: (q/(m*q+b))-(X/(m*X+b))+Y,
-            p: domainEnd,
+            q,
+            p,
+            // these are actually "stroke" q, p
+            newq: (q/(m*q+b))-(X/(m*X+b))+Y,
+            newp: (p/(m*p+b))-(X/(m*X+b))+Y,
           }
-          Y = domainEnd;
+          Y = (p/(m*p+b))-(X/(m*X+b))+Y
           X = p;
           return ret;
         });

--- a/index.html
+++ b/index.html
@@ -77,22 +77,24 @@
         if (!condition) console.error('ASSERTION FAILURE:', ...Array.from(arguments).slice(1));
       }
 
-      const leverage = 150;
+      const curveHeight = window.outerHeight / 3;
+      const curveWidth = window.innerWidth;
+
       const resolution = 6;
+      const maxLeverageMultiplier = 2;
+      const scale = curveHeight / maxLeverageMultiplier;
       assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
-      const points = Array(resolution).fill(leverage);
+      const points = Array(resolution).fill(1);
 
       function updatePoint(idx, diff) {
         points[idx] += diff;
-        const impactWidth = 20;
-        // get the number of nodes we have available around the index within the imapct width
         for (let i = 0; i < points.length; i++) {
           if (i === idx) continue;
           points[i] -= diff/(points.length-1);
         }
 
         avg = points.reduce((i, t) => i+t, 0) / points.length;
-        assert(avg.toFixed(2) === leverage.toFixed(2), 'Points in invalid state', points, avg);
+        assert(avg.toFixed(2) == 1, 'Points in invalid state', points, avg);
 
         drawCurve();
       }
@@ -101,8 +103,6 @@
       const curveCanvas = document.querySelector('canvas#curve');
       const curveContext = curveCanvas.getContext('2d');
 
-      const curveHeight = window.outerHeight / 3;
-      const curveWidth = window.innerWidth;
       curveCanvas.height = curveHeight;
       curveCanvas.width = curveWidth;
 
@@ -133,7 +133,7 @@
         }
 
         function getY(y) {
-          return curveHeight - y;
+          return scale*(maxLeverageMultiplier) - (y*scale);
         }
 
         const segmentWidth = curveWidth/(resolution-1);
@@ -170,7 +170,7 @@
         y = event.clientY;
         x = event.clientX;
         if (prevY == null) return;
-        updatePoint(currentX, prevY-y)
+        updatePoint(currentX, (prevY-y)/scale);
         prevY = y;
       });
       curveCanvas.addEventListener('mousedown', function(event) {

--- a/index.html
+++ b/index.html
@@ -73,13 +73,24 @@
         display: flex;
         align-items: start;
         justify-content: center;
-        width: 900px;
+        max-width: 900px;
         margin: 40px auto;
       }
 
       .column {
         width: 50%;
         flex-basis: 50%;
+      }
+
+      @media(max-width:1000px) {
+        .row {
+          flex-direction:column;
+          align-items:center;
+        }
+        .column {
+          width: 100%;
+          flex-basis: 100%;
+        }
       }
 
       .curve-container {
@@ -416,22 +427,36 @@
 
       // canvas interaction
       let x = 0, y = 0, prevY = null, currentX = null; 
-      curveCanvas.addEventListener('mousemove', function(event) {
+      function moveCurveEvent(event) {
+        event.preventDefault();
         const { left, top } = curveCanvas.getBoundingClientRect();
-        y = event.clientY-top;
-        x = event.clientX-left;
+        y = event.targetTouches ? event.targetTouches[0].clientY : event.clientY;
+        y -= top;
+        x = event.targetTouches ? event.targetTouches[0].clientX : event.clientX;
+        x -= left;
         if (prevY == null) return;
         updatePoint(currentX, (prevY-y)/scale);
         prevY = y;
-      });
-      curveCanvas.addEventListener('mousedown', function(event) {
-        prevY = y;
+      }
+      function startCurveEvent(event) {
+        event.preventDefault();
+        const { left, top } = curveCanvas.getBoundingClientRect();
+        prevY = event.targetTouches ? event.targetTouches[0].clientY : event.clientY;
+        prevY -= top;
+        x = event.targetTouches ? event.targetTouches[0].clientX : event.clientX;
+        x -= left;
         const i = Math.round(x/(curveWidth/(resolution-1)));
         if (i >= 0 && i < points.length) currentX = i;
-      });
-      document.addEventListener('mouseup', function(event) {
+      }
+      function endCurveEvent(event) {
         prevY = null;
-      });
+      }
+      curveCanvas.addEventListener('mousemove', moveCurveEvent);
+      curveCanvas.addEventListener('touchmove', moveCurveEvent);
+      curveCanvas.addEventListener('mousedown', startCurveEvent, {capture: true});
+      curveCanvas.addEventListener('touchstart', startCurveEvent, {capture: true});
+      document.addEventListener('mouseup', endCurveEvent);
+      document.addEventListener('touchend', endCurveEvent);
 
     </script>
 

--- a/index.html
+++ b/index.html
@@ -82,8 +82,47 @@
         flex-basis: 50%;
       }
 
-      canvas#curve {
-        outline: 2px solid red;
+      .curve-container {
+        padding-left: 40px;
+        padding-bottom: 30px;
+        position: relative;
+        margin: 0 1rem 3rem;
+      }
+      .curve-container > span {
+        text-align: right;
+        display: inline-block;
+        width: 30px;
+      }
+      .curve-container > span:nth-child(1) {
+        position: absolute;
+        top: 0;
+        transform: translateY(-50%);
+        left: 0;
+      }
+      .curve-container > span:nth-child(2) {
+        position: absolute;
+        top: calc(50% - 15px);
+        transform: translateY(-50%);
+        left: 0;
+      }
+      .curve-container > span:nth-child(3) {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+      }
+      .curve-container > span:nth-child(4) {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        transform: translateX(50%);
+      }
+
+      #curve {
+        border: 1px solid #eaeaea;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow:0 0.05em 0.15em #0000001a, 0 0.15em 0.9em #00000005;
+
       }
     </style>
   </head>
@@ -118,7 +157,13 @@
           </div>
         </form>
 
-        <canvas id="curve"></canvas>
+        <div class="curve-container">
+          <span id="double-leverage">2</span>
+          <span id="base-leverage">1</span>
+          <span>0</span>
+          <span id="wheel-travel-label">1</span>
+          <canvas id="curve"></canvas>
+        </div>
 
         <footer style="text-align:center;padding: 20px;">View code and license on <a href="https://github.com/RyanBerliner/coil-calculator">GitHub</a></footer>
       </div>
@@ -128,8 +173,8 @@
       let wheelTravel;
       let stroke;
       const curveCanvas = document.querySelector('canvas#curve');
-      const curveHeight = window.outerHeight / 3;
-      const curveWidth = curveCanvas.parentElement.offsetWidth;
+      const curveHeight = 200;
+      const curveWidth = curveCanvas.parentElement.offsetWidth-40;
 
       const resolution = 6;
       const maxLeverageMultiplier = 2;
@@ -320,11 +365,27 @@
       }
 
       function drawCurve() {
+        curveContext.clearRect(0, 0, curveWidth, curveHeight);
+        // gridlines
+        let num = 16;
+        for (let i = 0; i <= num; i++) {
+          curveContext.beginPath();
+          curveContext.lineWidth = 1;
+          let color = '#f0f0f0';
+          if (i % 4 == 0) {
+            color = '#c5c5c5';
+          }
+          curveContext.strokeStyle = color;
+          curveContext.moveTo(0, curveHeight/num*i);
+          curveContext.lineTo(curveWidth, curveHeight/num*i);
+          curveContext.stroke();
+        }
+
+        // the curve
         const curves = curveCubics();
         const segmentWidth = curveWidth/(resolution-1);
-        curveContext.clearRect(0, 0, curveWidth, curveHeight);
         curveContext.beginPath();
-        curveContext.lineWidth = 2;
+        curveContext.lineWidth = 3;
         curveContext.strokeStyle = '#000';
         curveContext.moveTo(0, getY(points[0]));
         let lastmod = 0;
@@ -370,6 +431,9 @@
       const springWeightInput = document.querySelector('input[name="spring-weight"]');
       const form = document.querySelector('form');
       const button = document.getElementById('simulate');
+      const baseLeverage = document.getElementById('base-leverage');
+      const doubleLeverage = document.getElementById('double-leverage');
+      const wheelTravelLabel = document.getElementById('wheel-travel-label');
 
       let riderWeight;
       let normWeight;
@@ -426,6 +490,10 @@
         wheelTravel = parseInt(data.get('travel') || 0);
         stroke = parseInt(data.get('stroke') || 1);
         springWeight = parseInt(data.get('spring-weight') || 0);
+
+        baseLeverage.innerHTML = (wheelTravel / stroke).toFixed(1);
+        doubleLeverage.innerHTML = (wheelTravel / stroke * 2).toFixed(1);
+        wheelTravelLabel.innerHTML = wheelTravel.toFixed(0);
 
         variables = getVariables();
 

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
       let stroke;
       const curveCanvas = document.querySelector('canvas#curve');
       const curveHeight = 200;
-      const curveWidth = curveCanvas.parentElement.offsetWidth-40-20;
+      const curveWidth = curveCanvas.parentElement.parentElement.offsetWidth-40-20;
 
       const resolution = 6;
       const maxLeverageMultiplier = 2;

--- a/index.html
+++ b/index.html
@@ -117,15 +117,16 @@
         let X = 0;
         let Y = 0;
         const strokeLineFuncs = travelLineFuncs.map(({m, b, q, p}) => {
+          const domainEnd = (p/(m*p+b))-(X/(m*X+b))+Y;
           const ret =  {
             m,
             b,
             X,
             Y,
-            q: ((1/m)*(Math.log((m*q) + b)))+Y-((1/m)*(Math.log((m*X)+b))),
-            p: ((1/m)*(Math.log((m*p) + b)-Math.log((m*X)+b)))+Y,
+            q: (q/(m*q+b))-(X/(m*X+b))+Y,
+            p: domainEnd,
           }
-          Y = ((1/m)*(Math.log((m*p) + b)-Math.log((m*X)+b)))+Y;
+          Y = domainEnd;
           X = p;
           return ret;
         });

--- a/index.html
+++ b/index.html
@@ -162,7 +162,10 @@
         let Y = 0;
         const strokeLineFuncs = travelLineFuncs.map(({m, b, q, p}) => {
           // the problem to solve is that if m === 0 this is undefined. need to find value as m approaches m
-          const yValueAtPofIntegral = ((Math.log(m*p+b)-Math.log(m*q+b))/m)+Y;
+          let yValueAtPofIntegral = ((Math.log(m*p+b)-Math.log(m*q+b))/m)+Y;
+          if (m === 0) {
+            yValueAtPofIntegral = ((p-q)/(m*p+b))+Y;
+          }
           const ret = {
             m,
             b,
@@ -179,8 +182,6 @@
           X = p;
           return ret;
         });
-
-        console.log(strokeLineFuncs);
 
         return strokeLineFuncs;
       }
@@ -209,7 +210,6 @@
         }
 
         const perPointDiff = (targetArea-area)/(resolution-1);
-        console.log('area, diff', area, perPointDiff);
 
         for (let i = 0; i < points.length-1; i++) {
           const x0 = i;
@@ -229,22 +229,6 @@
           }
         }
 
-        // TODO: only do verifacation like this when deving
-        // area = 0;
-        // for (let i = 0; i < points.length-1; i++) {
-        //   const x0 = i;
-        //   const x1 = i+1;
-        //   const y0 = 1/points[i];
-        //   const y1 = 1/points[i+1];
-        //   const m = (y1-y0)/(x1-x0);
-        //   const b = y0-(m*x0);
-        //   const q = x0;
-        //   const p = x1;
-        //   area += ((m*(Math.pow(p,2) - Math.pow(q,2)))/2) + (b*p) - (b*q)
-        // }
-        // console.assert(area < targetArea+0.1, 'Points in invalid state', area, targetArea);
-        // console.assert(area > targetArea-0.1, 'Points in invalid state', area, targetArea);
-
         getVariables();
         drawCurve();
         calculateCharacteristics();
@@ -262,7 +246,8 @@
           } = variables[i];
 
           function getVal(x) {
-            return (m*x) - (m*Y) + Math.log((m*X)+b) - Math.log((k*x) / (w*r));
+            let value = (m*x) - (m*Y) + Math.log((m*X)+b) - Math.log((k*x) / (w*r));
+            return value;
           }
 
           function getDer(x) {
@@ -272,7 +257,7 @@
           let inspecting = strokeq || 1/Number.MAX_SAFE_INTEGER;  // prevent /0 error when getting dir
           let iteration = 0;
           let lastValue = undefined;
-          const foundRoot = () => lastValue > -0.000001 && lastValue < 0.000001;
+          const foundRoot = () => lastValue > -0.01 && lastValue < 0.01;
           // this is newtons method https://en.wikipedia.org/wiki/Newton's_method
           while (iteration < 1000 && !foundRoot()) {
             iteration++;
@@ -281,12 +266,12 @@
             inspecting -= lastValue/dir;
           }
 
-          // TODO: consider making the top end unbounded for the last func (related to other todo)
           if (foundRoot() && inspecting >= strokeq && inspecting < strokep) {
             return inspecting;
           }
         }
-        return 0;
+
+        return NaN;
       }
 
       // Animation stuff

--- a/index.html
+++ b/index.html
@@ -128,6 +128,8 @@
     </div>
 
     <script>
+      let wheelTravel;
+      let stroke;
       const curveCanvas = document.querySelector('canvas#curve');
       const curveHeight = window.outerHeight / 3;
       const curveWidth = curveCanvas.parentElement.offsetWidth;
@@ -138,9 +140,9 @@
       console.assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
       const points = Array(resolution).fill(1);
 
-      function getVariables(travel, stroke) {
-        const baseLeverage = travel/stroke;
-        const piecewiseRange = travel / (resolution-1);
+      function getVariables() {
+        const baseLeverage = wheelTravel/stroke;
+        const piecewiseRange = wheelTravel / 25.4 / (resolution-1);
 
         const travelLineFuncs = [];
         for (let i = 0; i < points.length-1; i++) {
@@ -174,9 +176,8 @@
             q,
             p,
             // these are actually "stroke" q, p
-            // i think that these are wrong
-            strokeq: Y,// y value at integral of p
-            strokep: yValueAtPofIntegral, // y value at integral of q
+            strokeq: Y,
+            strokep: yValueAtPofIntegral,
           }
           Y = yValueAtPofIntegral;
           X = p;
@@ -375,8 +376,6 @@
 
       let riderWeight;
       let normWeight;
-      let wheelTravel;
-      let stroke;
       let sag;
       let springWeight;
       let simulating = false;
@@ -421,7 +420,7 @@
       }
 
       function leverageOfShockAtStroke(s) {
-        const variables = getVariables(wheelTravel / 25.4, stroke / 25.4); 
+        const variables = getVariables(); 
         for (let i = 0; i < variables.length; i++) {
           const {strokeq, strokep, m, Y, X, b} = variables[i];
           if (s < strokep && s >= strokeq) {
@@ -439,7 +438,7 @@
         stroke = parseInt(data.get('stroke') || 1);
         springWeight = parseInt(data.get('spring-weight') || 0);
 
-        const variables = getVariables(wheelTravel / 25.4, stroke / 25.4);
+        const variables = getVariables();
 
         // TODO: add in (part of) average weight of the bike itself?
         const rearTireBias = 0.65; // the rear wheel supports 65% of the riders weight

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
 
           <div>
             <strong style="font-size:1.2rem;">Calculated Sag</strong>
-            <span style="font-size:1.5rem;"><span id="sag-output"></span>% *</span>
+            <span style="font-size:1.5rem;"><span id="sag-output"></span>%</span>
           </div>
         </form>
 

--- a/index.html
+++ b/index.html
@@ -80,11 +80,59 @@
       const curveHeight = window.outerHeight / 3;
       const curveWidth = window.innerWidth;
 
-      const resolution = 6;
+      const resolution = 3;
       const maxLeverageMultiplier = 2;
       const scale = curveHeight / maxLeverageMultiplier;
       assert(resolution >= 2, 'Must use a curve resolution of 2 or higher');
       const points = Array(resolution).fill(1);
+
+      function makeSolvers() {
+        // TODO: remove the static values here & reference the globals
+        //       that are set in the shock specs
+        let travel = 160;
+        let stroke = 60;
+        const baseLeverage = travel/stroke;
+        const piecewiseRange = travel / (resolution-1);
+        console.log('base leverage', baseLeverage);
+        console.log('piecewise range', piecewiseRange);
+        console.log('points', points);
+
+        const travelLineFuncs = [];
+        for (let i = 0; i < points.length-1; i++) {
+          const x0 = i*piecewiseRange;
+          const x1 = (i+1)*piecewiseRange;
+          const y0 = points[i]*baseLeverage;
+          const y1 = points[i+1]*baseLeverage;
+          const m = (y1-y0)/(x1-x0);
+          const b = y0-(m*x0);
+          travelLineFuncs.push({
+            m,
+            b,
+            q: x0,
+            p: x1, // consider setting to inf (or undefined) for last point?)
+          });
+        }
+        console.log('travel line funcs', travelLineFuncs);
+
+        let X = 0;
+        let Y = 0;
+        const strokeLineFuncs = travelLineFuncs.map(({m, b, q, p}) => {
+          const ret =  {
+            m,
+            b,
+            X,
+            Y,
+            q: ((1/m)*(Math.log((m*q) + b)))+Y-((1/m)*(Math.log((m*X)+b))),
+            p: ((1/m)*(Math.log((m*p) + b)-Math.log((m*X)+b)))+Y,
+          }
+          Y = ((1/m)*(Math.log((m*p) + b)-Math.log((m*X)+b)))+Y;
+          X = p;
+          return ret;
+        });
+
+        console.log('stroke line funcs', strokeLineFuncs);
+
+      }
 
       function updatePoint(idx, diff) {
         points[idx] += diff;
@@ -96,6 +144,7 @@
         avg = points.reduce((i, t) => i+t, 0) / points.length;
         assert(avg.toFixed(2) == 1, 'Points in invalid state', points, avg);
 
+        makeSolvers();
         drawCurve();
       }
 
@@ -170,6 +219,7 @@
         curveContext.stroke();
       }
 
+      makeSolvers();
       drawCurve();
 
       // canvas interaction

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
       });
       curveCanvas.addEventListener('mousedown', function(event) {
         prevY = y;
-        const i = Math.round(x/(curveWidth/resolution));
+        const i = Math.round(x/(curveWidth/(resolution-1)));
         if (i >= 0 && i < points.length) currentX = i;
       });
       curveCanvas.addEventListener('mouseup', function(event) {

--- a/index.html
+++ b/index.html
@@ -422,6 +422,18 @@
         return parseInt(weight);
       }
 
+      function leverageOfShockAtStroke(s) {
+        const variables = getVariables(wheelTravel / 25.4, stroke / 25.4); 
+        for (let i = 0; i < variables.length; i++) {
+          const {strokeq, strokep, m, Y, X, b} = variables[i];
+          if (s < strokep && s >= strokeq) {
+            return Math.pow(Math.E, (m*s)-(m*Y)+Math.log((m*X)+b));
+          }
+        }
+        // default to the "average" so it at least doesn't break
+        return wheelTravel / stroke;
+      }
+
       function calculateCharacteristics() {
         const data = new FormData(form);
         riderWeight = parseInt(data.get('rider-weight') || 0);
@@ -712,6 +724,7 @@
 
       let last = 0;
 
+
       function doPhysics(timestamp) {
         requestAnimationFrame(doPhysics);
         if (!last) {
@@ -725,7 +738,7 @@
         const forces = [];
         let springConstant = springWeight * 4.448; // N/in
         springConstant = springConstant / 25.4; // N/mm
-        let weight = normWeight * 4.448; // N
+        let weight = normWeight * leverageOfShockAtStroke(pos / 25.4) * 4.448; // N
 
         forces.push(simulating ? weight : 0);
         forces.push(-springConstant * pos);

--- a/index.html
+++ b/index.html
@@ -231,6 +231,7 @@
       }
 
       function updatePoint(idx, diff) {
+        const previousPoints = points.slice();
         points[idx] += diff;
 
         const targetArea = resolution-1; // the target area of our inverse
@@ -271,6 +272,13 @@
             const end = recip(p);
             points[i+1] = 1/recip(p);
           }
+        }
+
+        // Stay withing chart bounds
+        if (Math.min(...points) < 0 || Math.max(...points) > 2) {
+          previousPoints.forEach((p, i) => {
+            points[i] = p;
+          });
         }
 
         variables = getVariables();
@@ -385,7 +393,7 @@
         const curves = curveCubics();
         const segmentWidth = curveWidth/(resolution-1);
         curveContext.beginPath();
-        curveContext.lineWidth = 3;
+        curveContext.lineWidth = 3.5;
         curveContext.strokeStyle = '#000';
         curveContext.moveTo(0, getY(points[0]));
         let lastmod = 0;
@@ -421,7 +429,7 @@
         const i = Math.round(x/(curveWidth/(resolution-1)));
         if (i >= 0 && i < points.length) currentX = i;
       });
-      curveCanvas.addEventListener('mouseup', function(event) {
+      document.addEventListener('mouseup', function(event) {
         prevY = null;
       });
 

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
         <input type="number" value="0" />
       </label>
     </div>
+    <canvas id="curve"></canvas>
     <script>
       const inputs = Array.from(document.querySelectorAll('input[type="number"]'));
       const averageInput = inputs[0];
@@ -108,6 +109,7 @@
         pointInputs.forEach(i => {
           i.value = parseFloat(i.value) + diff;
         });
+        drawCurve();
       });
 
       pointInputs.forEach(input => {
@@ -120,12 +122,68 @@
             if (i === input) return;
             i.value = parseFloat(i.value) + (diffTotal/(pointInputs.length-1));
           });
+          drawCurve();
         });
       });
-      
+
+      // Animation stuff
+      const curveCanvas = document.querySelector('canvas#curve');
+      const curveContext = curveCanvas.getContext('2d');
+
+      const curveHeight = window.outerHeight / 3;
+      const curveWidth = window.innerWidth;
+      curveCanvas.height = curveHeight;
+      curveCanvas.width = curveWidth;
+
+      if (window.devicePixelRatio > 1) {
+        curveCanvas.width = curveWidth * window.devicePixelRatio;
+        curveCanvas.height = curveHeight * window.devicePixelRatio;
+        curveCanvas.style.width = curveWidth + 'px';
+        curveCanvas.style.height = curveHeight + 'px';
+        curveContext.scale(window.devicePixelRatio, window.devicePixelRatio);  
+      }
+
+      function drawCurve() {
+        function getY(y) {
+          return curveHeight - y;
+        }
+        curveContext.clearRect(0, 0, curveWidth, curveHeight);
+        curveContext.beginPath();
+        curveContext.lineWidth = 2;
+        curveContext.strokeStyle = '#000';
+        curveContext.moveTo(100, getY(pointInputs[0].value));
+        for (let i = 1; i < pointInputs.length; i++) {
+          const inp = pointInputs[i];
+          curveContext.lineTo(100 * (i + 1), getY(inp.value));
+        }
+        curveContext.stroke();
+      }
+
+      drawCurve();
+
+      // canvas interaction
+      let x = 0, y = 0, prevY = null, currentX = null; 
+      curveCanvas.addEventListener('mousemove', function(event) {
+        y = event.clientY;
+        x = event.clientX;
+        if (currentX == null) return;
+        pointInputs[currentX].value = parseFloat(pointInputs[currentX].value) + (prevY - y);
+        pointInputs[currentX].dispatchEvent(new Event('change'));
+        prevY = y;
+      });
+      curveCanvas.addEventListener('mousedown', function(event) {
+        prevY = y;
+        const i = Math.round(x/100)-1;
+        if (i >= 0 && i < pointInputs.length) currentX = i;
+      });
+      curveCanvas.addEventListener('mouseup', function(event) {
+        prevY = null;
+        currentX = null;
+      });
+
     </script>
 
-    <canvas></canvas>
+    <canvas id="animation"></canvas>
     <button id="simulate"><span>Press & Hold</span><br/>to visualize sag</button>
     <form>
       <label>
@@ -253,7 +311,7 @@
 
       // the rest is the animation
 
-      const canvasNode = document.querySelector('canvas');
+      const canvasNode = document.querySelector('canvas#animation');
       const context = canvasNode.getContext('2d');
       let cHeight;
       let cWidth;

--- a/index.html
+++ b/index.html
@@ -68,17 +68,73 @@
         display:flex;
       }
       aside p {margin:0 0 0 10px;}
+
+      .row {
+        display: flex;
+        align-items: start;
+        justify-content: center;
+        width: 900px;
+        margin: 40px auto;
+      }
+
+      .column {
+        width: 50%;
+        flex-basis: 50%;
+      }
+
+      canvas#curve {
+        outline: 2px solid red;
+      }
     </style>
   </head>
   <body>
-    <canvas id="curve"></canvas>
+
+    <div class="row">
+      <div class="column">
+        <canvas id="animation"></canvas>
+        <button id="simulate"><span>Press & Hold</span><br/>to visualize sag</button>
+      </div>
+      <div class="column">
+        <form>
+          <label>
+            <span>Rider Weight (lbs)</span>
+            <input type="number" name="rider-weight" value="165">
+          </label>
+          <label>
+            <span>Rear wheel travel (mm)</span>
+            <input type="number" name="travel" value="160">
+          </label>
+          <label>
+            <span>Shock stroke (mm)</span>
+            <input type="number" name="stroke" value="60">
+          </label>
+          <label>
+            <span>
+              <strong>Spring Weight (lbs/in)</strong><br/>
+              Reset to 30% sag using <a href="#" data-sag="30"></a>
+            </span>
+            <input type="number" name="spring-weight" value="400">
+          </label>
+          <div>
+            <strong>Calculated Sag</strong>
+            <span style="font-size:1.5rem;"><span id="sag-output"></span>% *</span>
+          </div>
+        </form>
+
+        <canvas id="curve"></canvas>
+
+        <footer style="text-align:center;padding: 20px;">View code and license on <a href="https://github.com/RyanBerliner/coil-calculator">GitHub</a></footer>
+      </div>
+    </div>
+
     <script>
       function assert(condition) {
         if (!condition) console.error('ASSERTION FAILURE:', ...Array.from(arguments).slice(1));
       }
 
+      const curveCanvas = document.querySelector('canvas#curve');
       const curveHeight = window.outerHeight / 3;
-      const curveWidth = window.innerWidth;
+      const curveWidth = curveCanvas.parentElement.offsetWidth;
 
       const resolution = 3;
       const maxLeverageMultiplier = 2;
@@ -185,7 +241,6 @@
       }
 
       // Animation stuff
-      const curveCanvas = document.querySelector('canvas#curve');
       const curveContext = curveCanvas.getContext('2d');
 
       curveCanvas.height = curveHeight;
@@ -261,8 +316,9 @@
       // canvas interaction
       let x = 0, y = 0, prevY = null, currentX = null; 
       curveCanvas.addEventListener('mousemove', function(event) {
-        y = event.clientY;
-        x = event.clientX;
+        const { left, top } = curveCanvas.getBoundingClientRect();
+        y = event.clientY-top;
+        x = event.clientX-left;
         if (prevY == null) return;
         updatePoint(currentX, (prevY-y)/scale);
         prevY = y;
@@ -277,47 +333,6 @@
       });
 
     </script>
-
-    <canvas id="animation"></canvas>
-    <button id="simulate"><span>Press & Hold</span><br/>to visualize sag</button>
-    <form>
-      <label>
-        <span>Rider Weight (lbs)</span>
-        <input type="number" name="rider-weight" value="165">
-      </label>
-      <label>
-        <span>Rear wheel travel (mm)</span>
-        <input type="number" name="travel" value="160">
-      </label>
-      <label>
-        <span>Shock stroke (mm)</span>
-        <input type="number" name="stroke" value="60">
-      </label>
-      <label>
-        <span>
-          <strong>Spring Weight (lbs/in)</strong><br/>
-          Reset to 30% sag using <a href="#" data-sag="30"></a>
-        </span>
-        <input type="number" name="spring-weight" value="400">
-      </label>
-      <div>
-        <strong>Calculated Sag</strong>
-        <span style="font-size:1.5rem;"><span id="sag-output"></span>% *</span>
-      </div>
-    </form>
-
-    <aside style="padding:20px;">
-      <strong>*</strong>
-      <p>
-        The calculations taking place here currently assume a <em>linear</em>
-        suspension curve. Most frames have some level of "progressiveness" built into their design.
-        As a result the calculated sag displayed above will likely be <em>a little low</em>
-        when compared to reality. <a href="https://github.com/RyanBerliner/coil-calculator/issues/1">
-        This issue is noted here</a> and may be fixed in the future.
-      </p>
-    </aside>
-
-    <footer style="text-align:center;padding: 20px;">View code and license on <a href="https://github.com/RyanBerliner/coil-calculator">GitHub</a></footer>
 
     <script>
       const springWeightInput = document.querySelector('input[name="spring-weight"]');
@@ -419,7 +434,7 @@
 
       function setCanvas() {
         cHeight = window.outerHeight / 2;
-        cWidth = window.innerWidth;
+        cWidth = canvasNode.parentElement.offsetWidth;
         canvasNode.height = cHeight;
         canvasNode.width = cWidth;
 


### PR DESCRIPTION
closes #1 

adds support for different suspension platforms. does this by exposing a user customizable suspension curve. math and desktop interactivity currently works, just need to clean up a few more things

- [x] support for mobile (touch)
- [x] add bounds so you can NOT drag outside of chart (mouse leave safety etc)
- [x] add axis labels
- [x] add description and hide behind "advanced" setting
- [x] re-organize page elements page so it all fits together better
- [x] add some notes to the readme about how I derived the math equations (particularly for suspensive curves)
- [x] consider using a smaller y axis range? do some research of platforms to see what's most likely

have ideas for some presets for popular platforms or bikes,  and better ways to display sag (ie in a table for handful of rider weights and spring weights (lookup matrix/chart) but getting the math and chart in place needs to be done first.
